### PR TITLE
Add handle for AUDIOFOCUS_LOSS_TRANSIENT.

### DIFF
--- a/app/src/main/java/com/google/android/soundchecker/BaseFilePlayerActivity.kt
+++ b/app/src/main/java/com/google/android/soundchecker/BaseFilePlayerActivity.kt
@@ -195,7 +195,7 @@ open class BaseFilePlayerActivity : ComponentActivity(), OnAudioFocusChangeListe
     }
 
     private fun sendStartPlaybackMsg(delay: Int) {
-        sendMsg(START_PLAYBACK, 0, 0, null, 0)
+        sendMsg(START_PLAYBACK, 0, 0, null, delay)
     }
 
     protected fun sendStopPlaybackMsg(delay: Int) {


### PR DESCRIPTION
When the audio focus is lost transiently, stop the playback and restart the playback when the audio focus is gained.

Fixes #21.