### PR TITLE
MediaCodecTests: multichannel outputs and various bug fixes

### DIFF
--- a/app/src/main/java/com/google/android/soundchecker/AudioEncoderDecoderActivity.kt
+++ b/app/src/main/java/com/google/android/soundchecker/AudioEncoderDecoderActivity.kt
@@ -104,7 +104,7 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
     private var mStatus = mutableStateOf("")
     private var mBins: FloatArray? = null
     private var mSpectogram: MutableList<FloatArray?>? = null
-    private var mLastOutputBuffer: FloatArray? = null
+    private var mWaveforms: MutableList<FloatArray?>? = null
 
     private var mSpinnersEnabled = mutableStateOf(true)
     private var mSampleRateText = mutableStateOf("")
@@ -474,17 +474,22 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
                     Text(text = mStatus.value,
                             style = MaterialTheme.typography.titleSmall,
                             fontWeight = FontWeight.Bold)
-                    WaveformDisplay(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(WAVEFORM_HEIGHT.dp)
-                            .border(1.dp, Color.Gray)
-                            .background(Color.Green)
-                            .padding(horizontal = 4.dp, vertical = 4.dp),
-                        yValues = mLastOutputBuffer,
-                        yMin = -1.0f,
-                        yMax = 1.0f,
-                        shouldZoom = true)
+                    if (mWaveforms != null) {
+                        for (waveform in mWaveforms!!) {
+                            WaveformDisplay(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(WAVEFORM_HEIGHT.dp)
+                                    .border(1.dp, Color.Gray)
+                                    .background(Color.Green)
+                                    .padding(horizontal = 4.dp, vertical = 4.dp),
+                                yValues = waveform,
+                                yMin = -1.0f,
+                                yMax = 1.0f,
+                                shouldZoom = true
+                            )
+                        }
+                    }
                     WaveformDisplay(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -685,7 +690,7 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
             Toast.makeText(this, "Failed to init harmonic analyzer sink", Toast.LENGTH_LONG).show()
         }
 
-        mLastOutputBuffer = null
+        mWaveforms = null
         mBins = null
         mSpectogram = null
         mStatus.value = ""
@@ -732,7 +737,17 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
 
     private inner class MyHarmonicAnalyzerListener : HarmonicAnalyzerListener {
         override fun onMeasurement(analysisCount: Int, result: HarmonicAnalyzer.Result) {
-            mLastOutputBuffer = result.buffer
+            val numberOfSamples = result.buffer!!.size
+            val numberOfChannels = result.numOfChannels
+            val numberOfFrames = numberOfSamples / numberOfChannels
+            mWaveforms = mutableListOf<FloatArray?>()
+            for (channel in 0 until result.numOfChannels) {
+                val waveform = FloatArray(numberOfFrames)
+                for (frame in 0 until numberOfFrames) {
+                    waveform[frame] = result.buffer!![channel + frame * numberOfChannels]
+                }
+                mWaveforms!!.add(waveform)
+            }
             if (mInputFile != null) {
                 inputFileOnMeasurement(analysisCount, result)
             } else if (mPlaySineSweep.value) {

--- a/app/src/main/java/com/google/android/soundchecker/AudioEncoderDecoderActivity.kt
+++ b/app/src/main/java/com/google/android/soundchecker/AudioEncoderDecoderActivity.kt
@@ -741,7 +741,7 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
             val numberOfChannels = result.numOfChannels
             val numberOfFrames = numberOfSamples / numberOfChannels
             mWaveforms = mutableListOf<FloatArray?>()
-            for (channel in 0 until result.numOfChannels) {
+            for (channel in 0 until numberOfChannels) {
                 val waveform = FloatArray(numberOfFrames)
                 for (frame in 0 until numberOfFrames) {
                     waveform[frame] = result.buffer!![channel + frame * numberOfChannels]

--- a/app/src/main/java/com/google/android/soundchecker/harmonicanalyzer/HarmonicAnalyzer.kt
+++ b/app/src/main/java/com/google/android/soundchecker/harmonicanalyzer/HarmonicAnalyzer.kt
@@ -41,6 +41,7 @@ class HarmonicAnalyzer {
         var bins: FloatArray? = null
         var buffer: FloatArray? = null
         var endOfStream = false
+        var numOfChannels = 1
     }
 
     var peakMargin: Int

--- a/app/src/main/java/com/google/android/soundchecker/mediacodec/AudioEncoderDecoderFramework.kt
+++ b/app/src/main/java/com/google/android/soundchecker/mediacodec/AudioEncoderDecoderFramework.kt
@@ -42,6 +42,7 @@ class AudioEncoderDecoderFramework (codec: String, codecFormat: String, sampleRa
             AudioEncoderDecoderSink.TARGET_FREQUENCY)
         if (reader != null) {
             mWaveFileSource.waveFileReader = reader
+            mWaveFileSource.mChannelCount = channelCount
             mAudioEncoderSource.setSource(mWaveFileSource)
         } else {
             mSineSource.getAmplitudePort().set(0.5f)

--- a/app/src/main/java/com/google/android/soundchecker/mediacodec/AudioEncoderDecoderSink.kt
+++ b/app/src/main/java/com/google/android/soundchecker/mediacodec/AudioEncoderDecoderSink.kt
@@ -66,7 +66,7 @@ class AudioEncoderDecoderSink(outputFile: File): AudioSink() {
     }
 
     fun runAudioLoop() {
-        var outputBitsPerSample = 32
+        var outputBitsPerSample = 16
         if (mPcmEncoding == AudioFormat.ENCODING_PCM_FLOAT) {
             outputBitsPerSample = 24
         }
@@ -102,6 +102,7 @@ class AudioEncoderDecoderSink(outputFile: File): AudioSink() {
             } else {
                 result.buffer = floatArray
                 result.endOfStream = (outputSize != buffer.size)
+                result.numOfChannels = mChannelCount
             }
             fireListeners(count++, result)
         }

--- a/app/src/main/java/com/google/android/soundchecker/utils/SineSource.kt
+++ b/app/src/main/java/com/google/android/soundchecker/utils/SineSource.kt
@@ -103,9 +103,8 @@ class SineSource : AudioSource() {
 
     // Pull I16 bytes
     override fun pull(numBytes: Int, buffer: ByteArray): Int {
-        val int16SizeBytes = 2
-        val floatArray = FloatArray(numBytes / Float.SIZE_BYTES * int16SizeBytes)
-        pull(floatArray, numBytes / Float.SIZE_BYTES * int16SizeBytes / getChannelCount())
+        val floatArray = FloatArray(numBytes * Short.SIZE_BYTES / Float.SIZE_BYTES)
+        pull(floatArray, numBytes * Short.SIZE_BYTES / Float.SIZE_BYTES / getChannelCount())
         //Log.d(TAG, "floatArray: " + Arrays.toString(floatArray))
         floatArrayToI16ByteArray(floatArray, buffer)
         //Log.d(TAG, "byteArray: " + Arrays.toString(buffer))

--- a/app/src/main/java/com/google/android/soundchecker/utils/SineSource.kt
+++ b/app/src/main/java/com/google/android/soundchecker/utils/SineSource.kt
@@ -103,8 +103,9 @@ class SineSource : AudioSource() {
 
     // Pull I16 bytes
     override fun pull(numBytes: Int, buffer: ByteArray): Int {
-        val floatArray = FloatArray(numBytes / 2)
-        pull(floatArray, numBytes / 2)
+        val int16SizeBytes = 2
+        val floatArray = FloatArray(numBytes / Float.SIZE_BYTES * int16SizeBytes)
+        pull(floatArray, numBytes / Float.SIZE_BYTES * int16SizeBytes / getChannelCount())
         //Log.d(TAG, "floatArray: " + Arrays.toString(floatArray))
         floatArrayToI16ByteArray(floatArray, buffer)
         //Log.d(TAG, "byteArray: " + Arrays.toString(buffer))

--- a/app/src/main/java/com/google/android/soundchecker/utils/SineSource.kt
+++ b/app/src/main/java/com/google/android/soundchecker/utils/SineSource.kt
@@ -103,7 +103,7 @@ class SineSource : AudioSource() {
 
     // Pull I16 bytes
     override fun pull(numBytes: Int, buffer: ByteArray): Int {
-        val floatArray = FloatArray(numBytes / 2 * getChannelCount())
+        val floatArray = FloatArray(numBytes / 2)
         pull(floatArray, numBytes / 2)
         //Log.d(TAG, "floatArray: " + Arrays.toString(floatArray))
         floatArrayToI16ByteArray(floatArray, buffer)

--- a/app/src/main/java/com/google/android/soundchecker/utils/WaveFileSource.kt
+++ b/app/src/main/java/com/google/android/soundchecker/utils/WaveFileSource.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.soundchecker.utils
 
+import android.media.AudioFormat
 import android.util.Log
 import com.google.android.soundchecker.mediacodec.AudioEncoderSource
 import java.util.Arrays
@@ -36,9 +37,10 @@ class WaveFileSource : AudioSource() {
 
     // Pull I16 bytes
     override fun pull(numBytes: Int, buffer: ByteArray): Int {
-        val floatArray = FloatArray(numBytes / 2 * getChannelCount())
-        val framesRead = pull(floatArray, numBytes / 2)
-        //Log.d(TAG, "floatArray: " + Arrays.toString(floatArray))
+        val int16SizeBytes = 2
+        val floatArray = FloatArray(numBytes / Float.SIZE_BYTES * int16SizeBytes)
+        val framesRead = pull(floatArray, numBytes / Float.SIZE_BYTES *
+                int16SizeBytes / getChannelCount())
         floatArrayToI16ByteArray(floatArray, buffer)
         //Log.d(TAG, "byteArray: " + Arrays.toString(buffer))
         return framesRead

--- a/app/src/main/java/com/google/android/soundchecker/utils/WaveFileSource.kt
+++ b/app/src/main/java/com/google/android/soundchecker/utils/WaveFileSource.kt
@@ -37,10 +37,9 @@ class WaveFileSource : AudioSource() {
 
     // Pull I16 bytes
     override fun pull(numBytes: Int, buffer: ByteArray): Int {
-        val int16SizeBytes = 2
-        val floatArray = FloatArray(numBytes / Float.SIZE_BYTES * int16SizeBytes)
-        val framesRead = pull(floatArray, numBytes / Float.SIZE_BYTES *
-                int16SizeBytes / getChannelCount())
+        val floatArray = FloatArray(numBytes * Short.SIZE_BYTES / Float.SIZE_BYTES)
+        val framesRead = pull(floatArray, numBytes * Short.SIZE_BYTES / Float.SIZE_BYTES /
+                getChannelCount())
         floatArrayToI16ByteArray(floatArray, buffer)
         //Log.d(TAG, "byteArray: " + Arrays.toString(buffer))
         return framesRead


### PR DESCRIPTION
This PR changes the following:

1. AudioEncoderDecoderActivity now draws a waveform for each output channel.
2. Fixes a bug in WaveFileSource is multiplying by a num channels.
3. Fixes a bug in AudioEncoderDecoderSink where 16 bit output was written as 32 bit to a wave file.