### PR TITLE
MediaCodecTests: Support THD when output sample rates are different than input sample rates

### DIFF
--- a/app/src/main/java/com/google/android/soundchecker/AudioEncoderDecoderActivity.kt
+++ b/app/src/main/java/com/google/android/soundchecker/AudioEncoderDecoderActivity.kt
@@ -705,6 +705,7 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
         mBins = null
         mSpectogram = null
         mStatus.value = ""
+        mParam.value = ""
 
         mAudioEncoderDecoderFramework?.addListener(mListener)
 
@@ -717,11 +718,6 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
         if (mPlaySineSweep.value) {
             harmonicAnalyzerSink.mFundamentalBin = 0
         }
-
-        mParam.value = String.format("Sample Rate = %6d Hz\nFFT size = %d\nFundamental Bin = %d",
-                harmonicAnalyzerSink.mSampleRate,
-                harmonicAnalyzerSink.mFftSize,
-                harmonicAnalyzerSink.mFundamentalBin)
 
         mAudioEncoderDecoderFramework?.start()
     }
@@ -766,6 +762,11 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
             } else {
                 sineOnMeasurement(analysisCount, result)
             }
+
+            mParam.value = String.format("Decoded Sample Rate = %d Hz\nFFT size = %d\nFundamental Bin = %d",
+                mAudioEncoderDecoderFramework?.harmonicAnalyzerSink?.mSampleRate,
+                mAudioEncoderDecoderFramework?.harmonicAnalyzerSink?.mFftSize,
+                mAudioEncoderDecoderFramework?.harmonicAnalyzerSink?.mFundamentalBin)
 
             if (result.endOfStream) {
                 onStopTest()

--- a/app/src/main/java/com/google/android/soundchecker/mediacodec/AudioDecoderSource.kt
+++ b/app/src/main/java/com/google/android/soundchecker/mediacodec/AudioDecoderSource.kt
@@ -37,6 +37,8 @@ class AudioDecoderSource() : AudioSource() {
 
     private var inputArray = ByteArray(MAX_BYTES_TO_PULL)
 
+    private var harmonicAnalyzer: AudioEncoderDecoderSink? = null
+
     var isEndOfStream = false
     var isDecodingComplete = false
 
@@ -44,9 +46,14 @@ class AudioDecoderSource() : AudioSource() {
         audioSource = source
     }
 
+    fun setHarmonicAnalyzer(analyzer: AudioEncoderDecoderSink?) {
+        harmonicAnalyzer = analyzer
+    }
+
     fun setFormat(format: MediaFormat) {
         mChannelCount = format.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
         mSampleRate = format.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+        Log.d(TAG, "decoder sample rate: " + mSampleRate)
         inputFormat = MediaFormat.createAudioFormat(format.getString(MediaFormat.KEY_MIME)!!,
             mSampleRate, mChannelCount)
         val csd0Buffer = format.getByteBuffer("csd-0")
@@ -191,6 +198,7 @@ class AudioDecoderSource() : AudioSource() {
 
             if (outputIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
                 Log.d(TAG, "new output format: " + decoder!!.outputFormat)
+                harmonicAnalyzer?.setOutputFormat(decoder!!.outputFormat)
             }
 
             val isConfigFrame = bufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG != 0

--- a/app/src/main/java/com/google/android/soundchecker/mediacodec/AudioEncoderDecoderFramework.kt
+++ b/app/src/main/java/com/google/android/soundchecker/mediacodec/AudioEncoderDecoderFramework.kt
@@ -17,6 +17,7 @@
 package com.google.android.soundchecker.mediacodec
 
 import android.media.MediaMuxer
+import android.util.Log
 import com.google.android.soundchecker.harmonicanalyzer.HarmonicAnalyzerListener
 
 import com.google.android.soundchecker.utils.SineSource
@@ -61,9 +62,11 @@ class AudioEncoderDecoderFramework (codec: String, codecFormat: String, sampleRa
         mAudioDecoderSource.setSource(mAudioEncoderSource)
         mAudioEncoderSource.setDecoder(mAudioDecoderSource)
         harmonicAnalyzerSink.setSource(mAudioDecoderSource)
+        mAudioDecoderSource.setHarmonicAnalyzer(harmonicAnalyzerSink)
         harmonicAnalyzerSink.mChannelCount = channelCount
         harmonicAnalyzerSink.mFundamentalBin = bin
         harmonicAnalyzerSink.mUseAnalyzer = (reader == null)
+        harmonicAnalyzerSink.mUseFundamentalBin = (reader == null) && !usePitchSweep
     }
 
     fun start() {

--- a/app/src/main/java/com/google/android/soundchecker/mediacodec/AudioEncoderDecoderFramework.kt
+++ b/app/src/main/java/com/google/android/soundchecker/mediacodec/AudioEncoderDecoderFramework.kt
@@ -17,7 +17,6 @@
 package com.google.android.soundchecker.mediacodec
 
 import android.media.MediaMuxer
-import android.util.Log
 import com.google.android.soundchecker.harmonicanalyzer.HarmonicAnalyzerListener
 
 import com.google.android.soundchecker.utils.SineSource

--- a/app/src/main/java/com/google/android/soundchecker/mediacodec/AudioEncoderDecoderSink.kt
+++ b/app/src/main/java/com/google/android/soundchecker/mediacodec/AudioEncoderDecoderSink.kt
@@ -106,7 +106,7 @@ class AudioEncoderDecoderSink(outputFile: File): AudioSink() {
             if (mUseAnalyzer) {
                 var bin = mFundamentalBin
                 if (!mUseFundamentalBin) {
-                    bin = 0
+                    bin = 0 // Skip THD and SNR calculations when the input is not a sine wave
                 }
                 result = mAnalyzer.analyze(floatArray, mFftSize, bin)
             } else {


### PR DESCRIPTION
This PR makes several changes to support THD when output sample rates are different than input sample rates.
1. The output sample rate comes from the MediaCodec decoder so this needs to be dynamically passed into the harmonic analyzer sink.
2. When the sink gets the new sample rate, the bins need to be updated. The bin is set to zero when THD/SNR does not need to be calculated, aka when the input is not a sine wave.
3. The new sample rate should be used for the output file as well so the creation of the file is delayed until the first buffer is ready to be written. This allows time for the decoder to pass the output sample rate to the sink.
4. The UI for the status should be updated as the output sample rate isn't necessarily the input sample rate.

Fixes #36