### PR TITLE
MediaCodecTests: Fix initialization of mSpectrograms

### DIFF
--- a/app/src/main/java/com/google/android/soundchecker/AudioEncoderDecoderActivity.kt
+++ b/app/src/main/java/com/google/android/soundchecker/AudioEncoderDecoderActivity.kt
@@ -993,7 +993,7 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
 
     private fun sineSweepOnMeasurement(analysisCount: Int, results: ArrayList<HarmonicAnalyzer.Result>) {
         if (mSpectrograms == null) {
-            mSpectrograms = mutableListOf<MutableList<FloatArray?>?>(mutableListOf<FloatArray?>())
+            mSpectrograms = mutableListOf<MutableList<FloatArray?>?>()
             for (channel in 0 until results.size) {
                 mSpectrograms!!.add(mutableListOf<FloatArray?>())
             }


### PR DESCRIPTION
Without this, there's an extra line at the bottom of the screen for "Spectrogram for channel #2".

The issue is that mutableListOf<MutableList<FloatArray?>?>(mutableListOf<FloatArray?>()) creates an array of size 1