### PR TITLE
MediaCodecTests: Fix decoder name typo

### DIFF
--- a/app/src/main/java/com/google/android/soundchecker/AudioEncoderDecoderActivity.kt
+++ b/app/src/main/java/com/google/android/soundchecker/AudioEncoderDecoderActivity.kt
@@ -541,7 +541,7 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
                                         text = { Text(bin) },
                                         onClick = {
                                             mSelectedDecoder = mAudioDecoders!![index]
-                                            mEncoderText.value = mAudioDecoderStrings!![index]
+                                            mDecoderText.value = mAudioDecoderStrings!![index]
                                             updateDecoderStatus()
                                             expanded = false
                                         },


### PR DESCRIPTION
Fix a typo where setting the decoder changes the encoder name instead