### PR TITLE
MediaCodecTests: Add xHE-AAC MIME type

### DIFF
--- a/app/src/main/java/com/google/android/soundchecker/AudioEncoderDecoderActivity.kt
+++ b/app/src/main/java/com/google/android/soundchecker/AudioEncoderDecoderActivity.kt
@@ -318,7 +318,7 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
                             )
                         }
                     }
-                    if (mOutputFormatText.value == AUDIO_FORMAT_AAC) {
+                    if (mOutputFormatText.value == AUDIO_FORMAT_AAC || mOutputFormatText.value == AUDIO_FORMAT_XHE_AAC) {
                         Spacer(modifier = Modifier.padding(4.dp))
                         Row {
                             Text(text = "AAC profile")
@@ -1344,6 +1344,9 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
                 }
             }
         }
+        if (mAvailableOutputFormats!!.contains(AUDIO_FORMAT_AAC)) {
+            mAvailableOutputFormats!!.add(AUDIO_FORMAT_XHE_AAC)
+        }
         mOutputFormatText.value = mAvailableOutputFormats!!.get(0)
         updateSelectedFormat()
     }
@@ -1458,6 +1461,10 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
         updateEncoderStatus()
         updateCodecSpecificSpinnerValues()
 
+        var decoderSearchType = encoderType
+        if (encoderType == AUDIO_FORMAT_XHE_AAC) {
+            decoderSearchType = AUDIO_FORMAT_AAC
+        }
         mAudioDecoders = mutableListOf<MediaCodecInfo>()
         mAudioDecoderStrings = mutableListOf<String>()
         val mediaCodecList = MediaCodecList(MediaCodecList.REGULAR_CODECS)
@@ -1465,7 +1472,7 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
         for (info in mediaCodecInfos) {
             if (!info.isEncoder) {
                 for (decoderType in info.getSupportedTypes()) {
-                    if (decoderType == encoderType) {
+                    if (decoderType == decoderSearchType) {
                         val decoderCodecCapabilities: MediaCodecInfo.CodecCapabilities =
                             info.getCapabilitiesForType(decoderType)
                         val decoderAudioCapabilities: MediaCodecInfo.AudioCapabilities? =
@@ -1482,8 +1489,13 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
                 }
             }
         }
-        mSelectedDecoder = mAudioDecoders!!.get(0)
-        mDecoderText.value = mAudioDecoderStrings!!.get(0)
+        if (mAudioDecoders!!.isNotEmpty()) {
+            mSelectedDecoder = mAudioDecoders!!.get(0)
+            mDecoderText.value = mAudioDecoderStrings!!.get(0)
+        } else {
+            mSelectedDecoder = null
+            mDecoderText.value = "No decoder found"
+        }
         updateDecoderStatus()
     }
 
@@ -1625,6 +1637,7 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
         private const val INITIAL_FREQUENCIES_TO_PRINT = 5
         private val AUDIO_FORMAT_FLAC = MediaFormat.MIMETYPE_AUDIO_FLAC
         private val AUDIO_FORMAT_AAC = MediaFormat.MIMETYPE_AUDIO_AAC
+        private val AUDIO_FORMAT_XHE_AAC = "audio/mp4a.40.42"
         private val DEFAULT_SAMPLE_RATES = listOf(8000, 16000, 32000, 44100, 48000, 96000, 192000)
         private val DEFAULT_BITRATES = listOf(6000, 10000, 20000, 64000, 128000)
         // Arbitrary list of encoder delays in frames. These are used by the decoders to clip the early frames
@@ -1635,6 +1648,7 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
         private val SPECTOGRAM_WIDTH = 300
         private val AUDIO_FORMAT_TO_MEDIA_MUXER_OUTPUT_FORMAT = mapOf(
                 MediaFormat.MIMETYPE_AUDIO_AAC to MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4,
+                AUDIO_FORMAT_XHE_AAC to MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4,
                 MediaFormat.MIMETYPE_AUDIO_AMR_NB to MediaMuxer.OutputFormat.MUXER_OUTPUT_3GPP,
                 MediaFormat.MIMETYPE_AUDIO_AMR_WB to MediaMuxer.OutputFormat.MUXER_OUTPUT_3GPP,
                 MediaFormat.MIMETYPE_AUDIO_OPUS to MediaMuxer.OutputFormat.MUXER_OUTPUT_OGG,

--- a/app/src/main/java/com/google/android/soundchecker/AudioEncoderDecoderActivity.kt
+++ b/app/src/main/java/com/google/android/soundchecker/AudioEncoderDecoderActivity.kt
@@ -1344,8 +1344,10 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
                 }
             }
         }
-        if (mAvailableOutputFormats!!.contains(AUDIO_FORMAT_AAC)) {
-            mAvailableOutputFormats!!.add(AUDIO_FORMAT_XHE_AAC)
+        mAvailableOutputFormats?.let {
+            if (it.contains(AUDIO_FORMAT_AAC)) {
+                it.add(AUDIO_FORMAT_XHE_AAC)
+            }
         }
         mOutputFormatText.value = mAvailableOutputFormats!!.get(0)
         updateSelectedFormat()
@@ -1461,6 +1463,7 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
         updateEncoderStatus()
         updateCodecSpecificSpinnerValues()
 
+        // TODO: Consider adding an alias function if we need more exceptions.
         var decoderSearchType = encoderType
         if (encoderType == AUDIO_FORMAT_XHE_AAC) {
             decoderSearchType = AUDIO_FORMAT_AAC
@@ -1480,7 +1483,7 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
                         if (decoderAudioCapabilities != null) {
                             if (mInputFile == null || isFormatSupported(info, decoderType,
                                     mInputFileSampleRate, mInputFileNumChannels)) {
-                                mAudioDecoders!!.add(info)
+                                mAudioDecoders?.add(info)
                                 mAudioDecoderStrings!!.add(info.name)
                                 break
                             }
@@ -1637,7 +1640,7 @@ class AudioEncoderDecoderActivity : ComponentActivity() {
         private const val INITIAL_FREQUENCIES_TO_PRINT = 5
         private val AUDIO_FORMAT_FLAC = MediaFormat.MIMETYPE_AUDIO_FLAC
         private val AUDIO_FORMAT_AAC = MediaFormat.MIMETYPE_AUDIO_AAC
-        private val AUDIO_FORMAT_XHE_AAC = "audio/mp4a.40.42"
+        private val AUDIO_FORMAT_XHE_AAC = "audio/mp4a.40.42" // TODO: Replace with MediaFormat.MIMETYPE_AUDIO_XHE_AAC
         private val DEFAULT_SAMPLE_RATES = listOf(8000, 16000, 32000, 44100, 48000, 96000, 192000)
         private val DEFAULT_BITRATES = listOf(6000, 10000, 20000, 64000, 128000)
         // Arbitrary list of encoder delays in frames. These are used by the decoders to clip the early frames

--- a/app/src/main/java/com/google/android/soundchecker/mediacodec/AudioEncoderSource.kt
+++ b/app/src/main/java/com/google/android/soundchecker/mediacodec/AudioEncoderSource.kt
@@ -51,7 +51,7 @@ class AudioEncoderSource(val codec: String, val codecFormat: String, sampleRate:
         } else {
             outputFormat.setInteger(MediaFormat.KEY_BIT_RATE, bitRate)
         }
-        if (codecFormat == MediaFormat.MIMETYPE_AUDIO_AAC) {
+        if (codecFormat == MediaFormat.MIMETYPE_AUDIO_AAC || codecFormat == "audio/mp4a.40.42") {
             outputFormat.setInteger(MediaFormat.KEY_AAC_PROFILE, aacProfile)
         }
         outputFormat.setInteger(MediaFormat.KEY_PCM_ENCODING, pcmEncoding)


### PR DESCRIPTION
Adding xHE-AAC MIME type.

We can use MediaFormat.AUDIO_FORMAT_XHE_AAC but because it's only defined in Android 33, we end up having extra definition statements. I can add this in a follow-up PR as needed